### PR TITLE
Make sure new expressions are properly round-trippable

### DIFF
--- a/resources/levels/assign.json
+++ b/resources/levels/assign.json
@@ -4,81 +4,81 @@
     "levels": [
         {
             "description": "Introducing string values",
-            "board": "(== /(star) _)",
-            "toolbox": "(star) (diamond) (triangle)",
+            "board": "(== /star _)",
+            "toolbox": "(star) (rect) (triangle)",
             "goal": "(false)"
         },
         {
             "description": "Reducing a variable.",
             "board": "($_x)",
-            "goal": "(diamond)",
+            "goal": "(rect)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Variables can be reduced multiple times.",
             "board": "($_x) ($_x)",
-            "goal": "(diamond) (diamond)",
+            "goal": "(rect) (rect)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Multiple variables can be reduced.",
             "board": "($_x) ($_apple)",
-            "goal": "(diamond) (star)",
+            "goal": "(rect) (star)",
             "globals": {
-                "x": "(diamond)",
+                "x": "(rect)",
                 "apple": "(star)"
             }
         },
         {
             "description": "Assign to a variable.",
-            "board": "(assign /$x /star) ($_x)",
+            "board": "(assign $x /star) ($_x)",
             "goal": "(star)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Choose what to assign.",
-            "board": "(assign /$_x _) ($_x)",
+            "board": "(assign $x _) ($_x)",
             "goal": "(star)",
             "toolbox": "(triangle) (star)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Assign to an undefined variable.",
-            "board": "(assign /$y _) ($_y)",
+            "board": "(assign $y _) ($_y)",
             "goal": "(star)",
-            "toolbox": "(diamond) (star)"
+            "toolbox": "(rect) (star)"
         },
         {
             "description": "Multiple assignment.",
-            "board": "(assign /$x _) ($_x) (assign /$y _) ($_y)",
+            "board": "(assign $x _) ($_x) (assign $y _) ($_y)",
             "goal": "(star) (triangle)",
             "toolbox": "(triangle) (star)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Assignment order matters.",
-            "board": "(assign /$x /$y) (assign /$y /star) ($_x)",
+            "board": "(assign $x $y) (assign $y /star) ($_x)",
             "goal": "(star)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Assignment order still matters.",
-            "board": "(assign /$x /$y) (assign /$y /star) ($_x) ($_y)",
+            "board": "(assign $x $y) (assign $y /star) ($_x) ($_y)",
             "goal": "(star) (triangle)",
             "globals": {
-                "x": "(diamond)",
+                "x": "(rect)",
                 "y": "(triangle)"
             }
         },
@@ -88,25 +88,25 @@
             "goal": "(star) (triangle)",
             "toolbox": "($_x) ($_x) ($_y) ($_y)",
             "globals": {
-                "x": "(diamond)",
+                "x": "(rect)",
                 "y": "(triangle)"
             }
         },
         {
             "description": "Equality with a variable",
-            "board": "(== /$x /(diamond))",
+            "board": "(== $x /rect)",
             "goal": "(true)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Equality with a variable II",
-            "board": "(== _ /(diamond))",
+            "board": "(== _ /rect)",
             "goal": "(true)",
             "toolbox": "($x) ($y)",
             "globals": {
-                "x": "(diamond)",
+                "x": "(rect)",
                 "y": "(triangle)"
             }
         },
@@ -116,32 +116,32 @@
             "goal": "(true)",
             "toolbox": "(triangle) (star) ($x) ($y)",
             "globals": {
-                "x": "(diamond)",
-                "y": "(diamond)"
+                "x": "(rect)",
+                "y": "(rect)"
             }
         },
         {
             "description": "Make things equal first",
-            "board": "(== /$x /$y)",
+            "board": "(== $x $y)",
             "goal": "(true)",
             "toolbox": "(assign _ _) ($x) ($y)",
             "globals": {
-                "x": "(diamond)",
+                "x": "(rect)",
                 "y": "(triangle)"
             }
         },
         {
             "description": "Booleans can go in variables, too!",
-            "board": "(assign /$c /(== _ _)) ($_c)",
+            "board": "(assign $c /(== _ _)) ($_c)",
             "goal": "(true)",
-            "toolbox": "($x) (diamond) (star)",
+            "toolbox": "($x) (rect) (star)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Variable as value of conditional",
-            "board": "(if _b /$x)",
+            "board": "(if _b $x)",
             "goal": "(star)",
             "toolbox": "(true) (false)",
             "globals": {
@@ -150,8 +150,8 @@
         },
         {
             "description": "Variable as conditional of conditional",
-            "board": "(if _ /(diamond))",
-            "goal": "(diamond)",
+            "board": "(if _ /rect)",
+            "goal": "(rect)",
             "toolbox": "($c) ($x)",
             "globals": {
                 "c": "(true)",
@@ -160,17 +160,17 @@
         },
         {
             "description": "Unlock the conditional",
-            "board": "(if /$c /(diamond))",
-            "goal": "(diamond)",
-            "toolbox": "(assign /$c _ ) (true) (false)",
+            "board": "(if $c /rect)",
+            "goal": "(rect)",
+            "toolbox": "(assign $c _) (true) (false)",
             "globals": {
             }
         },
         {
             "description": "Unlock the conditional",
-            "board": "(if /$c /(diamond))",
-            "goal": "(diamond)",
-            "toolbox": "(assign /$c /(== _ _)) ($x) (star) (triangle)",
+            "board": "(if $c /rect)",
+            "goal": "(rect)",
+            "toolbox": "(assign $c /(== _ _)) ($x) (star) (triangle)",
             "globals": {
                 "x": "(star)"
             }
@@ -178,24 +178,24 @@
         {
             "description": "Building bags",
             "board": "(bag) ($x)",
-            "goal": "(bag diamond)",
+            "goal": "(bag rect)",
             "globals": {
-                "x": "(diamond)"
+                "x": "(rect)"
             }
         },
         {
             "description": "Bags can go in variables",
             "board": "",
-            "goal": "(bag star diamond)",
+            "goal": "(bag star rect)",
             "toolbox": "($x) ($y)",
             "globals": {
                 "x": "(bag star)",
-                "y": "(diamond)"
+                "y": "(rect)"
             }
         },
         {
             "description": "Comparing bags",
-            "board": "(== /$x /$y)",
+            "board": "(== $x $y)",
             "goal": "(true)",
             "toolbox": "(assign _ _) ($x) ($y)",
             "globals": {
@@ -204,16 +204,16 @@
         },
         {
             "description": "Constructing bags",
-            "board": "(if /(== /($x) /(star)) /(bag /(star)))",
+            "board": "(if /(== $x /star) /(bag star))",
             "goal": "(bag star)",
-            "toolbox": "(assign /($x) _) (diamond) (star)",
+            "toolbox": "(assign $x _) (rect) (star)",
             "globals": {
                 "x": "(triangle)"
             }
         },
         {
             "description": "Fade out variables",
-            "board": "(assign /$x /$y) (assign /$y /(triangle))",
+            "board": "(assign $x $y) (assign $y /triangle)",
             "goal": "(triangle)",
             "toolbox": "($x)",
             "globals": {
@@ -222,70 +222,70 @@
         },
         {
             "description": "Fade out variables II",
-            "board": "(if /$x /$y)",
-            "goal": "(diamond)",
-            "toolbox": "(assign _ _) ($x) ($y) (diamond) (star)",
+            "board": "(if $x $y)",
+            "goal": "(rect)",
+            "toolbox": "(assign _ _) ($x) ($y) (rect) (star)",
             "globals": {
                 "x": "(true)"
             }
         },
         {
             "description": "Basic lambdas work.",
-            "board": "(λx /$x)",
+            "board": "(λx $x)",
             "goal": "(star)",
-            "toolbox": "(diamond) (star)",
+            "toolbox": "(rect) (star)",
             "globals": {}
         },
         {
             "description": "Lambdas can produce comparisons based on input",
-            "board": "(λx /(== /$x /(triangle)))",
+            "board": "(λx /(== $x /triangle))",
             "goal": "(false)",
-            "toolbox": "(diamond) (star) (triangle)"
+            "toolbox": "(rect) (star) (triangle)"
         },
         {
             "description": "Lambdas can produce conditionals based on input",
-            "board": "(λx /(if /$x /(triangle)))",
+            "board": "(λx /(if $x /triangle))",
             "goal": "(triangle)",
             "toolbox": "(true) (false)"
         },
         {
             "description": "Lambdas can produce bags based on input",
-            "board": "(λx /(bag /$x))",
+            "board": "(λx /(bag $x))",
             "goal": "(bag triangle)",
-            "toolbox": "(diamond) (star) (triangle)"
+            "toolbox": "(rect) (star) (triangle)"
         },
         {
             "description": "Lambdas can produce comparisons based on input II",
-            "board": "(λx /(λy /(== /$x /$y)))",
+            "board": "(λx /(λy /(== $x $y)))",
             "goal": "(true)",
             "toolbox": "(star) (star) (triangle)"
         },
         {
             "description": "Lambdas can produce comparisons based on input III",
-            "board": "(λx /(λy /(== /$x /$y))) (λx /(if /$x /(diamond)))",
-            "goal": "(diamond)",
+            "board": "(λx /(λy /(== $x $y))) (λx /(if $x /rect))",
+            "goal": "(rect)",
             "toolbox": "(triangle) (star) (triangle)"
         },
         {
             "description": "Lambdas can read outside their environment.",
-            "board": "(λx /$y) ($y)",
+            "board": "(λx $y) ($y)",
             "goal": "(star) (star)",
-            "toolbox": "(diamond)",
+            "toolbox": "(rect)",
             "globals": {
                 "y": "(star)"
             }
         },
         {
             "description": "Outside changes are reflected in the lambda.",
-            "board": "(λx /$y) (assign /$y _)",
+            "board": "(λx $y) (assign $y _)",
             "goal": "(triangle)",
-            "toolbox": "(diamond) (star) (triangle)"
+            "toolbox": "(rect) (star) (triangle)"
         },
         {
             "description": "Outside changes are reflected in the lambda.",
-            "board": "(λx /$y)",
+            "board": "(λx $y)",
             "goal": "(triangle)",
-            "toolbox": "(diamond) (star) (triangle) (assign /$y _)",
+            "toolbox": "(rect) (star) (triangle) (assign $y _)",
             "globals": {
                 "y": "(star)"
             }

--- a/resources/levels/loops.json
+++ b/resources/levels/loops.json
@@ -15,7 +15,7 @@
         },
         {
             "description": "Variable in reduction",
-            "board": "(+ /($y) _)",
+            "board": "(+ $y _)",
             "goal": "(4)",
             "toolbox": "(1) (2)",
             "globals": {
@@ -24,7 +24,7 @@
         },
         {
             "description": "Assignment with addition",
-            "board": "(assign /$x /(+ _ /4))",
+            "board": "(assign $x /(+ _ /4))",
             "goal": "(6)",
             "toolbox": "($x) ($y)",
             "globals": {
@@ -34,7 +34,7 @@
         },
         {
             "description": "Order matters",
-            "board": "($x) ($x) (assign /$x /(+ /$x /1)) (assign /$x /4)",
+            "board": "($x) ($x) (assign $x /(+ $x /1)) (assign $x /4)",
             "goal": "(3) (4)",
             "globals": {
                 "x": "(2)"
@@ -42,7 +42,7 @@
         },
         {
             "description": "Order matters",
-            "board": "(sequence _ /(assign /$y /$x) _) (assign /$x /(+ /$x /1)) (assign /$x /4)",
+            "board": "(sequence _ /(assign $y $x) _) (assign $x /(+ $x /1)) (assign $x /4)",
             "goal": "(3) (4)",
             "toolbox": "($x) ($y)",
             "globals": {
@@ -53,14 +53,14 @@
             "description": "Increment things",
             "board": "(sequence _ _)",
             "goal": "(3)",
-            "toolbox": "($x) (assign /$x /(+ /$x /1)) (assign /$x /(+ /$x /1))",
+            "toolbox": "$x (assign $x /(+ $x /1)) (assign $x /(+ $x /1))",
             "globals": {
                 "x": "(1)"
             }
         },
         {
             "description": "Increment things with repeat",
-            "board": "($x) (repeat /(2) /(assign /$x /(+ /$x /1)))",
+            "board": "$x (repeat /2 /(assign $x /(+ $x /1)))",
             "goal": "(3)",
             "toolbox": "",
             "globals": {
@@ -69,7 +69,7 @@
         },
         {
             "description": "Increment things with repeat",
-            "board": "($x) ($y) (repeat /(4) /(assign /$x /(+ /$x /1))) (repeat /(1) /(assign /$y /(+ /$y /1)))",
+            "board": "($x) ($y) (repeat /4 /(assign $x /(+ $x /1))) (repeat /1 /(assign $y /(+ $y /1)))",
             "goal": "(5) (1)",
             "toolbox": "",
             "globals": {
@@ -79,7 +79,7 @@
         },
         {
             "description": "Increment things with repeat",
-            "board": "($x) (repeat _ /(assign /$x /(+ /$x /1)))",
+            "board": "($x) (repeat _ /(assign $x /(+ $x /1)))",
             "goal": "(4)",
             "toolbox": "(0) (1) (2) (3)",
             "globals": {
@@ -88,7 +88,7 @@
         },
         {
             "description": "You can repeat a variable number of times",
-            "board": "($x) (repeat /$x /(assign /$x /(+ /$x /1)))",
+            "board": "($x) (repeat $x /(assign $x /(+ $x /1)))",
             "toolbox": "",
             "goal": "(4)",
             "globals": {
@@ -97,7 +97,7 @@
         },
         {
             "description": "You can repeat a variable number of times",
-            "board": "(sequence /(repeat /$x /(assign /$x /(+ /$x /1))) /(assign /$y /(== /$x _))) ($y)",
+            "board": "(sequence /(repeat $x /(assign $x /(+ $x /1))) /(assign $y /(== $x _))) $y",
             "toolbox": "(4) (5) (6)",
             "goal": "(true)",
             "globals": {
@@ -107,7 +107,7 @@
         },
         {
             "description": "Use sequence in repeat",
-            "board": "($x) ($y) (repeat /(2) /(sequence /(assign /$x /(+ /$x _)) /(assign /$y /(+ /$y _))))",
+            "board": "($x) ($y) (repeat /2 /(sequence /(assign $x /(+ $x _)) /(assign $y /(+ $y _))))",
             "goal": "(3) (6)",
             "toolbox": "(0) (1) (2)",
             "globals": {
@@ -117,7 +117,7 @@
         },
         {
             "description": "Overwriting variables",
-            "board": "($x) ($y) (assign /$y /(4)) (assign /$x /(3)) (assign /$y /(5)) (sequence _ _ _)",
+            "board": "($x) ($y) (assign $y /4) (assign $x /3) (assign $y /5) (sequence _ _ _)",
             "goal": "(1) (4)",
             "toolbox": "",
             "globals": {
@@ -127,7 +127,7 @@
         },
         {
             "description": "Use sequence in repeat with dependencies",
-            "board": "($y) (repeat /(3) /(sequence /(assign /$x /(+ /$x /1)) /(assign /$y /(== /$x _))))",
+            "board": "($y) (repeat /3 /(sequence /(assign $x /(+ $x /1)) /(assign $y /(== $x _))))",
             "goal": "(true)",
             "toolbox": "(3) (4) (5) (6)",
             "globals": {
@@ -136,7 +136,7 @@
         },
         {
             "description": "Use sequence in repeat with dependencies",
-            "board": "($y) (repeat /(2) /(sequence /(assign /$x /(+ /$x /1)) /(assign /$y /(if /(== /$x _) /(star)))))",
+            "board": "($y) (repeat /2 /(sequence /(assign $x /(+ $x /1)) /(assign $y /(if /(== $x _) /star))))",
             "goal": "(star)",
             "toolbox": "(1) (2) (3)",
             "globals": {

--- a/resources/levels/mystery.json
+++ b/resources/levels/mystery.json
@@ -12,7 +12,7 @@
         },
         {
             "description": "The choice block",
-            "board": "(choice (2) (3) (4) (5) (6))",
+            "board": "(choice 2 3 4 5 6)",
             "goal": "(6)",
             "toolbox": "",
             "globals": {
@@ -20,7 +20,7 @@
         },
         {
             "description": "The choice block",
-            "board": "(choice (2) (3)) (choice (4) (5))",
+            "board": "(choice 2 3) (choice 4 5)",
             "goal": "(2) (4)",
             "toolbox": "",
             "globals": {
@@ -28,7 +28,7 @@
         },
         {
             "description": "The choice block",
-            "board": "(== _ _) (choice (star) (false)) (choice (2) (3) ($x))",
+            "board": "(== _ _) (choice star false) (choice 2 3 $x)",
             "goal": "(true)",
             "toolbox": "",
             "globals": {
@@ -37,7 +37,7 @@
         },
         {
             "description": "The choice block",
-            "board": "(assign /$x (star)) ($x) (choice (== _ /(star)) (== _ /(triangle)))",
+            "board": "(assign $x star) ($x) (choice (== _ /star) (== _ /triangle))",
             "goal": "(false)",
             "toolbox": "",
             "globals": {
@@ -45,16 +45,16 @@
         },
         {
             "description": "The choice block",
-            "board": "(assign /$x /(+ /$x /1))",
+            "board": "(assign $x /(+ $x /1))",
             "goal": "(3)",
-            "toolbox": "($x) (choice (2) (+ /$x /1)) (choice (assign /$x _) (repeat _ _))",
+            "toolbox": "($x) (choice 2 (+ $x /1)) (choice (assign $x _) (repeat _ _))",
             "globals": {
                 "x": "(1)"
             }
         },
         {
             "description": "The choice block",
-            "board": "($x) (choice (assign /$x _) (repeat _ _) (== _ _)) (choice (triangle) (star) (diamond))",
+            "board": "($x) (choice (assign $x _) (repeat _ _) (== _ _)) (choice triangle star rect)",
             "goal": "(triangle)",
             "toolbox": "",
             "globals": {
@@ -62,9 +62,9 @@
         },
         {
             "description": "The choice block",
-            "board": "($y) (repeat /(3) /(sequence /(assign /$x /(+ /$x /1)) /(assign /$y _)))",
+            "board": "($y) (repeat /3 /(sequence /(assign $x /(+ $x /1)) /(assign $y _)))",
             "goal": "(true)",
-            "toolbox": "(choice (assign /$x _) (repeat /$x _) (== /$x _) (if /$x _)) (choice (1) (2) (3) (4) (5) (6))",
+            "toolbox": "(choice (assign $x _) (repeat $x _) (== $x _) (if $x _)) (choice 1 2 3 4 5 6)",
             "globals": {
                 "x": "(2)",
                 "y": "(false)"
@@ -72,7 +72,7 @@
         },
         {
             "description": "Snappables",
-            "board": "($x) (snappable /(assign /$x /(star))) (snappable /(assign /$x /(diamond)) (snappable /(assign /$x /(circle))))",
+            "board": "($x) (snappable /(assign $x /star)) (snappable /(assign $x /rect) (snappable /(assign $x /circle)))",
             "goal": "(star)",
             "toolbox": "",
             "globals": {
@@ -80,7 +80,7 @@
         },
         {
             "description": "Snappables",
-            "board": "($y) (snappable /(assign /$x /3)) (snappable /(assign /$y /$x)) (snappable /(assign /$x /5))",
+            "board": "($y) (snappable /(assign $x /3)) (snappable /(assign $y $x)) (snappable /(assign $x /5))",
             "goal": "(3)",
             "toolbox": "",
             "globals": {
@@ -88,7 +88,7 @@
         },
         {
             "description": "Snappables",
-            "board": "($x) (snappable /(assign /$x /(star))) (snappable /(repeat /3 /(assign /$x /(+ /$x /1)))) (snappable /(assign /$x /2))",
+            "board": "($x) (snappable /(assign $x /star)) (snappable /(repeat /3 /(assign $x /(+ $x /1)))) (snappable /(assign $x /2))",
             "goal": "(5)",
             "toolbox": "",
             "globals": {
@@ -96,9 +96,9 @@
         },
         {
             "description": "Snappables",
-            "board": "($z) (snappable /(assign /$z /(== /$x /$y)))",
+            "board": "($z) (snappable /(assign $z /(== $x $y)))",
             "goal": "(true)",
-            "toolbox": "(snappable /(assign /$x /(+ /$x /1))) (snappable /(assign /$y /$x))",
+            "toolbox": "(snappable /(assign $x /(+ $x /1))) (snappable /(assign $y $x))",
             "globals": {
                 "x": "(1)",
                 "y": "(3)"
@@ -106,15 +106,15 @@
         },
         {
             "description": "Snappables",
-            "board": "($y) (snappable /(assign /$x _)) (snappable /(assign /$y /$x))",
+            "board": "($y) (snappable /(assign $x _)) (snappable /(assign $y $x))",
             "goal": "(star)",
-            "toolbox": "(diamond) (star) (triangle)",
+            "toolbox": "(rect) (star) (triangle)",
             "globals": {
             }
         },
         {
             "description": "Snappables",
-            "board": "($x) (snappable /(assign /$x /(== /$x _))) (snappable /(assign /$x /(star))) (snappable /(assign /$x /(diamond))) (choice (diamond) (triangle) (circle))",
+            "board": "($x) (snappable /(assign $x /(== $x _))) (snappable /(assign $x /star)) (snappable /(assign $x /rect)) (choice rect triangle circle)",
             "goal": "(true)",
             "toolbox": "",
             "globals": {
@@ -122,17 +122,17 @@
         },
         {
             "description": "Snappables",
-            "board": "($z) (snappable /(assign /$z _)) (choice (== /$x _) (== /$x /(circle))) (snappable /(assign /$x /(diamond))) (choice (star) (diamond))",
+            "board": "($z) (snappable /(assign $z _)) (choice (== $x _) (== $x /circle)) (snappable /(assign $x /rect)) (choice star rect)",
             "goal": "(circle)",
-            "toolbox": "(if _ /(circle))",
+            "toolbox": "(if _ /circle)",
             "globals": {
             }
         },
         {
             "description": "Snappables with loops",
-            "board": "(snappable /(assign /$x /(+ /$x /(1)))) (snappable /(assign /$y /(+ /$y /(1))))",
+            "board": "(snappable /(assign $x /(+ $x /1))) (snappable /(assign $y /(+ $y /1)))",
             "goal": "(2) (3)",
-            "toolbox": "($x) ($y) (repeat /(2) _)",
+            "toolbox": "($x) ($y) (repeat /2 _)",
             "globals": {
                 "x": "(1)",
                 "y": "(0)"
@@ -140,18 +140,18 @@
         },
         {
             "description": "Fade sequences",
-            "board": "(if /$x /(star)) (snappable /(assign /$x /(== /$y /(triangle)))) (snappable /(assign /$y _))",
+            "board": "(if $x /star) (snappable /(assign $x /(== $y /triangle))) (snappable /(assign $y _))",
             "goal": "(star)",
-            "toolbox": "(triangle) (diamond)",
+            "toolbox": "(triangle) (rect)",
             "globals": {
                 "x": "(false)"
             }
         },
         {
             "description": "Force snappable usage with loops",
-            "board": "(snappable /(assign /$x /(if /(== /$y /(3)) /(true)))) (snappable /(assign /$y /(+ /$y /(1))))",
+            "board": "(snappable /(assign $x /(if /(== $y /3) /true))) (snappable /(assign $y /(+ $y /1)))",
             "goal": "(true)",
-            "toolbox": "($x) (repeat /(3) _)",
+            "toolbox": "($x) (repeat /3 _)",
             "globals": {
                 "x": "(false)",
                 "y": "(0)"
@@ -159,7 +159,7 @@
         },
         {
             "description": "Fade repeat",
-            "board": "($x) (repeat /(2) /(sequence /(assign /$x /(+ /$x /1))))",
+            "board": "($x) (repeat /2 /(sequence /(assign $x /(+ $x /1))))",
             "goal": "(3)",
             "toolbox": "",
             "globals": {
@@ -168,7 +168,7 @@
         },
         {
             "description": "Fade repeat",
-            "board": "($x) ($y) (repeat _ /(sequence /(assign /$x /(+ /$x /1)) /(assign /$y /(+ /$y /2))))",
+            "board": "($x) ($y) (repeat _ /(sequence /(assign $x /(+ $x /1)) /(assign $y /(+ $y /2))))",
             "goal": "(3) (5)",
             "toolbox": "(0) (1) (2)",
             "globals": {
@@ -178,7 +178,7 @@
         },
         {
             "description": "Fade repeat",
-            "board": "($x) (repeat /2 _) (choice (assign /$x /(+ /$x _)) (assign /$y /(+ /$y _))) (choice (0) (1) ($x) ($y))",
+            "board": "($x) (repeat /2 _) (choice (assign $x /(+ $x _)) (assign $y /(+ $y _))) (choice 0 1 $x $y)",
             "goal": "(4)",
             "toolbox": "",
             "globals": {

--- a/resources/levels/sequence.json
+++ b/resources/levels/sequence.json
@@ -4,33 +4,33 @@
     "levels": [
         {
             "description": "Sequence operator",
-            "board": "(sequence /(assign /($x) _) /(assign /($y) /($x))) ($y)",
-            "goal": "(diamond)",
-            "toolbox": "(star) (diamond) (triangle)"
+            "board": "(sequence /(assign $x _) /(assign $y $x)) ($y)",
+            "goal": "(rect)",
+            "toolbox": "(star) (rect) (triangle)"
         },
         {
             "description": "Bigger sequence",
-            "board": "(sequence /(assign /($x) /(triangle)) /(assign /($y) _) /(assign /($z) /(== /($x) /($y)))) ($z)",
+            "board": "(sequence /(assign $x /triangle) /(assign $y _) /(assign $z /(== $x $y))) ($z)",
             "goal": "(false)",
             "toolbox": "(star) (triangle)"
         },
         {
             "description": "Bigger sequence",
-            "board": "(sequence /(assign /($x) _) /(assign /($y) _) /(assign /($z) /(== /($x) /($y)))) ($z)",
+            "board": "(sequence /(assign $x _) /(assign $y _) /(assign $z /(== $x $y))) ($z)",
             "goal": "(true)",
             "toolbox": "(star) (star) (triangle) (triangle)"
         },
         {
             "description": "Fill in the blank",
-            "board": "(sequence /(assign /($z) _) _ /(assign /($y) /($x)))",
+            "board": "(sequence /(assign $z _) _ /(assign $y $x))",
             "goal": "(star)",
             "toolbox": "(star) (assign _ _) ($x) ($y) ($z)"
         },
         {
             "description": "Swap the variables",
-            "board": "(sequence /(assign /($z) /($x)) _ _ /(assign /$z /(diamond)))",
+            "board": "(sequence /(assign $z $x) _ _ /(assign $z /rect))",
             "goal": "(star)",
-            "toolbox": "($y) (assign /($x) /$y) /(assign /($y) /$z)",
+            "toolbox": "($y) (assign $x $y) /(assign $y $z)",
             "globals": {
                 "x": "(star)",
                 "y": "(triangle)"
@@ -38,9 +38,9 @@
         },
         {
             "description": "Unlock the conditional",
-            "board": "(sequence /(assign /($y) _) /(assign /($c) /(== /($y) /(diamond))) /(assign /($y) /(if /$c /$x))) ($y)",
+            "board": "(sequence /(assign $y _) /(assign $c /(== $y /rect)) /(assign $y /(if $c $x))) ($y)",
             "goal": "(star)",
-            "toolbox": "(triangle) (diamond)",
+            "toolbox": "(triangle) (rect)",
             "globals": {
                 "x": "(star)"
             }

--- a/src/expr/choice.js
+++ b/src/expr/choice.js
@@ -279,4 +279,9 @@ class ChoiceExpr extends Expression {
             return !this._sparkling;
         });
     }
+
+    toString() {
+        let children = this.choices.map((x) => x.toString()).join(" ");
+        return `(choice ${children})`;
+    }
 }

--- a/src/expr/expression.js
+++ b/src/expr/expression.js
@@ -556,7 +556,7 @@ class Expression extends mag.RoundedRect {
         let side = notch.side;
         let pos = this.upperLeftPos( this.pos, this.size );
         if (side === 'left')
-            return { x: pos.x, y: pos.y + this.radius  + (this.size.h - this.radius) * (1 - notch.relpos)) * this.scale.y };
+            return { x: pos.x, y: pos.y + this.radius  + (this.size.h - this.radius) * (1 - notch.relpos) * this.scale.y };
         else if (side === 'right')
             return { x: pos.x + this.size.w * this.scale.x, y: pos.y + (this.radius + (this.size.h - this.radius * 2) * notch.relpos)*this.scale.y };
         else if (side === 'top')

--- a/src/expr/loops.js
+++ b/src/expr/loops.js
@@ -297,6 +297,12 @@ class RepeatLoopExpr extends Expression {
             this.performReduction();
         }
     }
+
+    toString() {
+        let times = this.timesExpr.toString();
+        let body = this.bodyExpr.toString();
+        return `${this.locked ? '/' : ''}(repeat ${times} ${body})`;
+    }
 }
 
 class FadedRepeatLoopExpr extends Expression {

--- a/src/expr/sequence.js
+++ b/src/expr/sequence.js
@@ -136,6 +136,10 @@ class Sequence extends Expression {
             this.performReduction();
         }
     }
+
+    toString() {
+        return `${this.locked ? '/' : ''}(sequence ${this.subexpressions.map((x) => x.toString()).join(" ")})`;
+    }
 }
 
 class NotchedSequence extends Sequence {

--- a/src/expr/snappable.js
+++ b/src/expr/snappable.js
@@ -1,6 +1,7 @@
 class Snappable extends Expression {
     constructor(expr, next=null) {
         super([expr]);
+        this.origNext = next;
         this.topDivotStroke = this.bottomDivotStroke = null;
         this.divotHeight = 6;
         this.prev = null;
@@ -282,6 +283,14 @@ class Snappable extends Expression {
         }
 
         stage.swap(this, new (ExprManager.getClass('sequence'))(...body));
+    }
+
+    toString() {
+        let next = "";
+        if (this.origNext) {
+            next = " " + this.origNext.toString();
+        }
+        return `(snappable ${this.contents.toString()}${next})`;
     }
 }
 

--- a/src/expr/value.js
+++ b/src/expr/value.js
@@ -174,12 +174,12 @@ class MirrorExpr extends ImageExpr {
 
 /** Faded variants. */
 class FadedValueExpr extends Expression {
-    constructor(name) {
+    constructor(name, primitiveName=null) {
         let txt = new TextExpr(name);
         super([txt]);
         txt.color = "OrangeRed";
         this.color = "gold";
-        this.primitiveName = name;
+        this.primitiveName = primitiveName || name;
     }
     get graphicNode() { return this.holes[0]; }
     reduceCompletely() { return this; }
@@ -198,20 +198,20 @@ class FadedRectExpr extends FadedValueExpr {
     constructor() { super('rect'); }
 }
 class FadedTriangleExpr extends FadedValueExpr {
-    constructor() { super('tri'); }
+    constructor() { super('tri', 'triangle'); }
 }
 class FadedCircleExpr extends FadedValueExpr {
-    constructor() { super('dot'); }
+    constructor() { super('dot', 'circle'); }
 }
 
 class StringValueExpr extends Expression {
-    constructor(name) {
+    constructor(name, primitiveName=null) {
         let text = new TextExpr('"' + name + '"');
         super([text]);
         this.primitiveName = name;
         text.color = "OrangeRed";
         this.color = "gold";
-        this.primitiveName = name;
+        this.primitiveName = primitiveName || name;
     }
 
     get graphicNode() { return this.holes[0]; }
@@ -231,8 +231,8 @@ class StringRectExpr extends StringValueExpr {
     constructor() { super('rect'); }
 }
 class StringTriangleExpr extends StringValueExpr {
-    constructor() { super('tri'); }
+    constructor() { super('tri', 'triangle'); }
 }
 class StringCircleExpr extends StringValueExpr {
-    constructor() { super('dot'); }
+    constructor() { super('dot', 'circle'); }
 }

--- a/src/expr/var.js
+++ b/src/expr/var.js
@@ -581,6 +581,12 @@ class AssignExpr extends Expression {
             this.performReduction();
         }
     }
+
+    toString() {
+        let variable = this.variable ? this.variable.toString() : '_';
+        let value = this.value ? this.value.toString() : '_';
+        return `${this.locked ? '/' : ''}(assign ${variable} ${value})`;
+    }
 }
 
 class JumpingAssignExpr extends AssignExpr {

--- a/src/frame/game.js
+++ b/src/frame/game.js
@@ -421,6 +421,8 @@ class Level {
             return lambdavar;
         } else if (arg.indexOf('$') > -1) {
             let varname = arg.replace('$', '').replace('_', '');
+            // Lock unless there is an underscore in the name
+            locked = !(arg.indexOf('_') > -1);
             return lock(new (ExprManager.getClass('reference'))(varname), locked);
         } else {
             console.error('Unknown argument: ', arg);


### PR DESCRIPTION
Rectangle is now canonically "rect" and circle is canonically "circle".

There are a couple failures in the map chapter that I haven't touched.

I haven't explicitly unlocked variables that are in the top level of the stage, as the stage automatically unlocks it, but I can go back and do that if needed (and I want to go back and make sure I didn't lock/unlock anything by accident).