### PR TITLE
[WIP] Unified reduction indicator

### DIFF
--- a/lib/lowLag.js
+++ b/lib/lowLag.js
@@ -94,9 +94,10 @@ var lowLag = new function(){
 
 
 		var format = "sm2";
+		var browserAudioContext = window.AudioContext || window.webkitAudioContext;
 		if(force != undefined) format = force;
 		else {
-			if(typeof(webkitAudioContext) != "undefined") format = 'webkitAudio';
+			if(typeof(browserAudioContext) != "undefined") format = 'webkitAudio';
 			else if(navigator.userAgent.indexOf("Firefox")!=-1) format = 'audioTag';
 		}
 		switch(format){
@@ -105,7 +106,7 @@ var lowLag = new function(){
 				this.msg("init webkitAudio");
 				this.load= this.loadSoundWebkitAudio;
 				this.play = this.playSoundWebkitAudio;
-				this.webkitAudioContext = new webkitAudioContext();
+				this.webkitAudioContext = new browserAudioContext();
 				if (this.useSuspension &= ('suspend' in lowLag.webkitAudioContext && 'onended' in lowLag.webkitAudioContext.createBufferSource())) {
 					this.playingQueue = [];
 					this.suspendPlaybackWebkitAudio();

--- a/resources/levels/loops.json
+++ b/resources/levels/loops.json
@@ -56,7 +56,7 @@
             "description": "Increment things",
             "board": "(sequence _ _)",
             "goal": "(3)",
-            "toolbox": "$x (assign $x /(+ $x /1)) (assign $x /(+ $x /1))",
+            "toolbox": "($x) (assign $x /(+ $x /1)) (assign $x /(+ $x /1))",
             "globals": {
                 "x": "(1)"
             }

--- a/src/core/stage.js
+++ b/src/core/stage.js
@@ -310,6 +310,23 @@ var mag = (function(_) {
             return rt;
         }
 
+        static getAllNodes(nodes, excludedNodes=[], recursive=true) {
+            let result = [];
+
+            nodes.forEach((n) => {
+                if (excludedNodes.indexOf(n) > -1) return;
+                else {
+                    result.push(n);
+                }
+
+                if (recursive && n.children.length > 0) {
+                    result = result.concat(Stage.getAllNodes(n.children, excludedNodes, true));
+                }
+            });
+
+            return result;
+        }
+
         /** Invalidates this stage, so that it won't draw to canvas or receive events. */
         invalidate() {
             this.invalidated = true;

--- a/src/expr/compare.js
+++ b/src/expr/compare.js
@@ -49,6 +49,7 @@ class CompareExpr extends Expression {
                 if (this.leftExpr != before) {
                     return this.performReduction();
                 }
+                return Promise.reject("Left expression did not reduce!");
             });
         }
 
@@ -60,6 +61,7 @@ class CompareExpr extends Expression {
                 if (this.rightExpr != before) {
                     return this.performReduction();
                 }
+                return Promise.reject("Right expression did not reduce!");
             });
         }
 
@@ -76,7 +78,7 @@ class CompareExpr extends Expression {
             }
             else super.performReduction();
         }
-        return null;
+        return Promise.reject("Cannot reduce!");
     }
     compare() {
         if (this.funcName === '==') {
@@ -180,15 +182,20 @@ class MirrorCompareExpr extends CompareExpr {
 
     // Animation effects
     performReduction() {
-        if (!this.isReducing && this.reduce() != this) {
-            var stage = this.stage;
-            var shatter = new MirrorShatterEffect(this.mirror);
-            shatter.run(stage, (() => {
-                this.ignoreEvents = false;
-                super.performReduction(false);
-            }).bind(this));
-            this.ignoreEvents = true;
-            this.isReducing = true;
-        }
+        return new Promise((resolve, reject) => {
+            if (!this.isReducing && this.reduce() != this) {
+                var stage = this.stage;
+                var shatter = new MirrorShatterEffect(this.mirror);
+                shatter.run(stage, (() => {
+                    this.ignoreEvents = false;
+                    resolve(super.performReduction(false));
+                }).bind(this));
+                this.ignoreEvents = true;
+                this.isReducing = true;
+            }
+            else {
+                reject();
+            }
+        });
     }
 }

--- a/src/expr/compare.js
+++ b/src/expr/compare.js
@@ -22,9 +22,7 @@ class CompareExpr extends Expression {
     get rightExpr() { return this.holes[2]; }
     onmouseclick(pos) {
         console.log('Expressions are equal: ', this.compare());
-        if (!this._animating) {
-            this.performReduction();
-        }
+        this.performUserReduction();
     }
 
     reduce() {
@@ -41,11 +39,9 @@ class CompareExpr extends Expression {
     }
 
     performReduction(animated=true) {
-        if (this.leftExpr && this.rightExpr && !this.leftExpr.isValue() && !this._animating) {
+        if (this.leftExpr && this.rightExpr && !this.leftExpr.isValue() && !this._reducing) {
             let before = this.leftExpr;
-            this._animating = true;
             return this.performSubReduction(this.leftExpr, true).then(() => {
-                this._animating = false;
                 if (this.leftExpr != before) {
                     return this.performReduction();
                 }
@@ -53,11 +49,9 @@ class CompareExpr extends Expression {
             });
         }
 
-        if (this.leftExpr && this.rightExpr && !this.rightExpr.isValue() && !this._animating) {
-            this._animating = true;
+        if (this.leftExpr && this.rightExpr && !this.rightExpr.isValue() && !this._reducing) {
             let before = this.rightExpr;
             return this.performSubReduction(this.rightExpr, true).then(() => {
-                this._animating = false;
                 if (this.rightExpr != before) {
                     return this.performReduction();
                 }

--- a/src/expr/conditional.js
+++ b/src/expr/conditional.js
@@ -59,7 +59,7 @@ class IfStatement extends Expression {
         else if (this.cond && !this.cond.isValue() && !this.cond.canReduce()) {
             // Try and play any animation anyways
             this.cond.performReduction();
-            return null;
+            return Promise.reject("IfExpr: cannot reduce condition");
         }
 
         if (this.branch && this.branch.canReduce()) {

--- a/src/expr/conditional.js
+++ b/src/expr/conditional.js
@@ -22,7 +22,7 @@ class IfStatement extends Expression {
     get constructorArgs() { return [this.cond.clone(), this.branch.clone()]; }
 
     onmouseclick(pos) {
-        this.performReduction();
+        this.performUserReduction();
     }
 
     reduce() {

--- a/src/expr/expression.js
+++ b/src/expr/expression.js
@@ -291,8 +291,8 @@ class Expression extends mag.RoundedRect {
             this.stroke = {
                 lineWidth: 3,
                 color: "lightblue",
-                lineDash: [5, 5],
-                lineDashOffset: this._reducingTime / 500,
+                lineDash: [5, 10],
+                lineDashOffset: this._reducingTime,
             };
         }
     }
@@ -302,7 +302,7 @@ class Expression extends mag.RoundedRect {
         if (!this._reducing) {
             if (!this.canReduce()) {
                 mag.Stage.getAllNodes([this]).forEach((n) => {
-                    if (n.isPlaceholder()) {
+                    if (n instanceof Expression && n.isPlaceholder()) {
                         n.animatePlaceholderStatus();
                     }
                 });
@@ -328,6 +328,10 @@ class Expression extends mag.RoundedRect {
     // Try and reduce the given child expression before continuing with our reduction
     performSubReduction(expr, animated=true) {
         return new Promise((resolve, reject) => {
+            if (expr.isValue() || !expr.canReduce()) {
+                resolve(expr);
+                return;
+            }
             let result = expr.performReduction(animated);
             if (result instanceof Promise) {
                 result.then((result) => {

--- a/src/expr/expression.js
+++ b/src/expr/expression.js
@@ -314,6 +314,8 @@ class Expression extends mag.RoundedRect {
             this._reducing = this.performReduction(true);
             this._reducing.then(() => {
                 this._reducing = false;
+            }, () => {
+                this._reducing = false;
             });
         }
         return this._reducing;

--- a/src/expr/expression.js
+++ b/src/expr/expression.js
@@ -248,12 +248,23 @@ class Expression extends mag.RoundedRect {
 
     // Is this expression missing any subexpressions?
     isComplete() {
+        if (this.isPlaceholder()) return false;
         for (let child of this.holes) {
-            if (child instanceof MissingExpression || (child instanceof Expression && !child.isComplete())) {
+            if (child instanceof Expression && !child.isComplete()) {
                 return false;
             }
         }
         return true;
+    }
+
+    // Is this expression a placeholder for something else?
+    isPlaceholder() {
+        return false;
+    }
+
+    // Play an animation to remind the user that this is a placeholder.
+    animatePlaceholderStatus() {
+        Animate.blink(this);
     }
 
     // Reduce this expression to another.

--- a/src/expr/expression.js
+++ b/src/expr/expression.js
@@ -300,7 +300,7 @@ class Expression extends mag.RoundedRect {
 
             console.warn('performReduction with ', this, reduced_expr);
 
-            if (!this.stage) return;
+            if (!this.stage) return Promise.reject();
 
             this.stage.saveState();
             Logger.log('state-save', this.stage.toString());
@@ -329,8 +329,9 @@ class Expression extends mag.RoundedRect {
             if (reduced_expr)
                 reduced_expr.update();
 
-            return reduced_expr;
+            return Promise.resolve(reduced_expr);
         }
+        return Promise.resolve(this);
     }
     reduceCompletely() { // Try to reduce this expression and its subexpressions as completely as possible.
         var e = this;

--- a/src/expr/lambda.js
+++ b/src/expr/lambda.js
@@ -626,6 +626,7 @@ class LambdaExpr extends Expression {
         } else return super.reduce();
     }
     performReduction(animated=false) {
+        // TODO: need to convert performReductions here
         // If we don't have all our arguments, refuse to evaluate.
         if (this.takesArgument) {
             return this;

--- a/src/expr/missing.js
+++ b/src/expr/missing.js
@@ -17,7 +17,7 @@ class MissingExpression extends Expression {
         this._size = { w:expr_to_miss.size.w, h:expr_to_miss.size.h };
         this.ghost = expr_to_miss;
     }
-    isComplete() { return false; }
+    isPlaceholder() { return true; }
     getClass() { return MissingExpression; }
     onmousedrag(pos) {
         // disable drag

--- a/src/expr/null.js
+++ b/src/expr/null.js
@@ -15,7 +15,7 @@ class NullExpr extends ImageExpr {
     }
     performReduction() {
         Animate.poof(this);
-        super.performReduction();
+        return super.performReduction();
     }
     onmousehover() {
         this.image = 'null-circle-highlight';

--- a/src/expr/number.js
+++ b/src/expr/number.js
@@ -70,15 +70,12 @@ class AddExpr extends Expression {
     }
 
     performReduction() {
-        this._animating = true;
         return this.performSubReduction(this.leftExpr).then((left) => {
             if (!(left instanceof NumberExpr)) {
-                this._animating = false;
                 return Promise.reject();
             }
             return this.performSubReduction(this.rightExpr).then((right) => {
                 if (!(right instanceof NumberExpr)) {
-                    this._animating = false;
                     return Promise.reject();
                 }
 
@@ -92,9 +89,7 @@ class AddExpr extends Expression {
     }
 
     onmouseclick() {
-        if (!this._animating) {
-            this.performReduction();
-        }
+        this.performUserReduction();
     }
 
     toString() {

--- a/src/expr/recall.js
+++ b/src/expr/recall.js
@@ -34,6 +34,10 @@ class TypeBox extends mag.Rect {
         this.textExpr.fontSize = fs;
     }
 
+    isPlaceholder() {
+        return true;
+    }
+
     onmouseenter(pos) {
         //this.focus();
         this.stroke = { color:'blue', lineWidth:2 };

--- a/src/expr/recall.js
+++ b/src/expr/recall.js
@@ -216,6 +216,8 @@ class TypeInTextExpr extends TextExpr {
     constructor(validator, afterCommit, charLimit=1) {
         super(" ");
 
+        this.validator = validator;
+
         if (!afterCommit) {
             afterCommit = (txt) => {
                 let expr = __PARSER.parse(txt);
@@ -261,6 +263,15 @@ class TypeInTextExpr extends TextExpr {
             return super.size;
         }
     }
+
+    reduce() {
+        let txt = this.typeBox.text.trim();
+        if (this.validator(txt)) {
+            return __PARSER.parse(txt);
+        }
+        return this;
+    }
+
     commit(renderedText) {
         this.text = renderedText; // this is the underlying text in the TextExpr
         this.removeChild(this.typeBox);
@@ -277,6 +288,9 @@ class TypeInTextExpr extends TextExpr {
     focus() { this.typeBox.focus(); this.typeBox.onmouseleave(); }
     blur() { this.typeBox.blur(); }
     isValue() { return false; }
-    canReduce() { return false; }
+    canReduce() {
+        let txt = this.typeBox.text.trim();
+        return this.validator(txt);
+    }
     value() { return undefined; }
 }

--- a/src/expr/sequence.js
+++ b/src/expr/sequence.js
@@ -46,10 +46,11 @@ class Sequence extends Expression {
 
     performReduction() {
         if (!this.canReduce()) {
+            // TODO: this should be overridable
             mag.Stage.getNodesWithClass(MissingExpression, [], true, [this]).forEach((node) => {
                 Animate.blink(node);
             });
-            return null;
+            return Promise.reject("Sequence is incomplete");
         }
 
         this._animating = true;

--- a/src/expr/sequence.js
+++ b/src/expr/sequence.js
@@ -23,7 +23,6 @@ class Sequence extends Expression {
 
     canReduce() {
         for (let expr of this.holes) {
-            if (expr instanceof MissingExpression) return false;
             if (!expr.isComplete()) return false;
         }
         return true;
@@ -46,9 +45,10 @@ class Sequence extends Expression {
 
     performReduction() {
         if (!this.canReduce()) {
-            // TODO: this should be overridable
-            mag.Stage.getNodesWithClass(MissingExpression, [], true, [this]).forEach((node) => {
-                Animate.blink(node);
+            mag.Stage.getAllNodes([this]).forEach((n) => {
+                if (n.isPlaceholder()) {
+                    n.animatePlaceholderStatus();
+                }
             });
             return Promise.reject("Sequence is incomplete");
         }

--- a/src/expr/sequence.js
+++ b/src/expr/sequence.js
@@ -44,17 +44,6 @@ class Sequence extends Expression {
     }
 
     performReduction() {
-        if (!this.canReduce()) {
-            mag.Stage.getAllNodes([this]).forEach((n) => {
-                if (n.isPlaceholder()) {
-                    n.animatePlaceholderStatus();
-                }
-            });
-            return Promise.reject("Sequence is incomplete");
-        }
-
-        this._animating = true;
-
         let cleanup = () => {
             this._animating = false;
             while (this.holes.length > 0 && this.holes[0] instanceof MissingExpression) {
@@ -71,7 +60,6 @@ class Sequence extends Expression {
                 if (this.holes.length === 0) {
                     Animate.poof(this);
                     (this.parent || this.stage).swap(this, null);
-                    this._animating = false;
                     resolve(null);
                 }
                 else {
@@ -133,8 +121,19 @@ class Sequence extends Expression {
     }
 
     onmouseclick() {
-        if (!this._animating) {
-            this.performReduction();
+        this.performUserReduction();
+    }
+
+    drawReductionIndicator(ctx, pos, boundingSize) {
+        if (this._reducing) {
+            const radius = this.radius*this.absoluteScale.x;
+            const rightMargin = 15 * this.scale.x;
+
+            const rad = rightMargin / 3;
+            const indicatorX = pos.x + boundingSize.w - rightMargin / 2 - rad;
+            const verticalDistance = boundingSize.h - 2 * this.radius;
+            const verticalOffset = 0.5 * (1.0 + Math.sin(this._reducingTime / 250)) * verticalDistance;
+            drawCircle(ctx, indicatorX, pos.y + radius + verticalOffset, rad, "lightblue", null);
         }
     }
 
@@ -179,25 +178,6 @@ class NotchedSequence extends Sequence {
             ctx.lineTo(pos.x + boundingSize.w, expr1y);
             ctx.stroke();
         }
-
-        if (this._animating) {
-            const rad = rightMargin / 3;
-            const indicatorX = pos.x + boundingSize.w - rightMargin / 2 - rad;
-            const verticalDistance = boundingSize.h - 2 * radius;
-            const verticalOffset = 0.5 * (1.0 + Math.sin((Date.now() - this._reductionIndicatorStart) / 250)) * verticalDistance;
-            drawCircle(ctx, indicatorX, pos.y + radius + verticalOffset, rad, "#000", null);
-        }
-    }
-
-    performReduction() {
-        let result = super.performReduction();
-
-        Animate.drawUntil(this.stage, () => {
-            return !this._animating || !this.stage;
-        });
-        this._reductionIndicatorStart = Date.now();
-
-        return result;
     }
 }
 

--- a/src/expr/snappable.js
+++ b/src/expr/snappable.js
@@ -264,8 +264,7 @@ class Snappable extends Expression {
 
     performReduction() {
         if (this.prev) {
-            this.prev.performReduction();
-            return;
+            return this.prev.performReduction();
         }
 
         // Save stage since it gets erased down the line
@@ -283,6 +282,7 @@ class Snappable extends Expression {
         }
 
         stage.swap(this, new (ExprManager.getClass('sequence'))(...body));
+        return Promise.resolve(null);
     }
 
     toString() {

--- a/src/expr/value.js
+++ b/src/expr/value.js
@@ -110,7 +110,7 @@ class NullExpr extends ImageExpr {
     }
     performReduction() {
         Animate.poof(this);
-        super.performReduction();
+        return super.performReduction();
     }
     onmousehover() {
         this.image = 'null-circle-highlight';

--- a/src/expr/var.js
+++ b/src/expr/var.js
@@ -578,9 +578,7 @@ class AssignExpr extends Expression {
             return;
         }
 
-        if (!this._animating) {
-            this.performReduction();
-        }
+        this.performUserReduction();
     }
 
     toString() {

--- a/src/expr/var.js
+++ b/src/expr/var.js
@@ -138,7 +138,7 @@ class LabeledVarExpr extends VarExpr {
             value = value.clone();
             let parent = this.parent ? this.parent : this.stage;
             parent.swap(this, value);
-            return value;
+            return Promise.resolve(value);
         }
         else {
             let wat = new TextExpr("?");
@@ -156,7 +156,7 @@ class LabeledVarExpr extends VarExpr {
                 this.stage.draw();
                 this.stage.update();
             }, 500);
-            return null;
+            return Promise.reject("Cannot reduce undefined variable");
         }
     }
 }
@@ -237,14 +237,15 @@ class ChestVarExpr extends VarExpr {
     }
 
     performReduction(animated=true) {
-        if (this.parent && this.parent instanceof AssignExpr && this.parent.variable == this) return null;
+        if (this.parent && this.parent instanceof AssignExpr && this.parent.variable == this)
+            return Promise.reject("Cannot reduce LHS of assignment");
 
         let value = this.reduce();
         if (value != this) {
             if (!animated) {
                 let parent = this.parent ? this.parent : this.stage;
                 parent.swap(this, value);
-                return null;
+                return Promise.resolve(value);
             }
             this._animating = true;
             return this.animateReduction(value, true);
@@ -259,9 +260,8 @@ class ChestVarExpr extends VarExpr {
                     this.stage.update();
                 }, 500);
             });
-            return null;
         }
-        return null;
+        return Promise.reject("Cannot reduce undefined variable");
     }
 
     animateReduction(value, destroy) {
@@ -328,7 +328,8 @@ class ChestVarExpr extends VarExpr {
 
 class JumpingChestVarExpr extends ChestVarExpr {
     performReduction(animated=true) {
-        if (this.parent && this.parent instanceof AssignExpr && this.parent.variable == this) return null;
+        if (this.parent && this.parent instanceof AssignExpr && this.parent.variable == this)
+            return Promise.reject("Cannot reduce LHS of assignment");
 
         if (!animated || !this.stage) {
             return super.performReduction(animated);
@@ -542,7 +543,7 @@ class AssignExpr extends Expression {
             this.getEnvironment().update(this.variable.name, value);
             this.stage.environmentDisplay.update();
             this.stage.draw();
-            return null;
+            return Promise.resolve(null);
         }
 
         this._animating = true;

--- a/src/util.js
+++ b/src/util.js
@@ -133,6 +133,8 @@ function SET_CURSOR_STYLE(style) {
          if (stroke.lineDash)
              ctx.setLineDash(stroke.lineDash);
          else ctx.setLineDash([]);
+
+         ctx.lineDashOffset = stroke.lineDashOffset || 0;
      }
  }
  function strokeWithOpacity(ctx, opacity) {


### PR DESCRIPTION
Changes:

- Most `performReduction` calls in `src/expr` now return a Promise
- Added `performUserReduction`, intended for use inside `onmouseclick`. This will check `canReduce`, blink any unfilled holes if necessary, and call `performReduction`, showing an indicator for the reduction. The indicator is simply animating the border of the element by default (it works better for most expressions, I feel) but can be overridden.
- Added `Expression#isPlaceholder` to distinguish expressions that are placeholders for others. (So we now have `canReduce`, `isValue`, `isComplete`, and `isPlaceholder`)
- Added `Expression#animatePlaceholderStatus` to play the 'blink' effect for incomplete expressions
- Make `TypeInTextBox` automatically reduce when a parent expression is clicked

TODO:

- [ ] Convert `lambda.js`, `define.js` and `apply.js` and make sure they work with the new reduction mechanics
- [ ] Double-check implementations of `canReduce`, etc.

Other than this, I'm mostly working on deploying the BOOM edition. I've printed the poster already.