### PR TITLE
Bugfixes (more incoming)

### DIFF
--- a/src/frame/reductstage.js
+++ b/src/frame/reductstage.js
@@ -362,6 +362,9 @@ class ReductStage extends mag.Stage {
             if (key === 8) { // BACKSPACE
                 this.keyEventDelegate.backspace();
             }
+            else if (key === 46 || key === 127) { // DELETE
+                this.keyEventDelegate.backspace(-1);
+            }
             else if (key === 37) { // LEFT ARROW
                 this.keyEventDelegate.leftArrow();
             }
@@ -390,6 +393,11 @@ class ReductStage extends mag.Stage {
         if (this.keyEventDelegate) {
             if (event.keyCode === 13) {
                 this.keyEventDelegate.carriageReturn();
+            }
+            else if (event.keyCode === 8 || event.keyCode === 46 ||
+                     event.keyCode === 37 || event.keyCode === 39 ||
+                     event.keyCode === 127) {
+                // Special character, do nothing
             }
             else if (event.keyCode === 9) { // Tab.
                 // Cycle to next possible keyEventDelegate...


### PR DESCRIPTION
Others I want to address/noticed

- [ ] Level 22: lambda doesn't lock concatenation operations passed through it

- [ ] Level 24: if you start reduction, then drag a subexpression out while it's reducing, final value is locked

- [ ] Level 26: after fading, goal can be dragged

- [x] General text boxes: can't backspace/delete

- [ ] Level 32: should be able to compare lambda and square, or we should disallow applying lambda to lambda in this case

- [ ] Ditto for level 39

- [ ] Level 40: type "t" and lock text box; produces nonfunctional lambda

- [ ] Typing a nested lambda: inner lambdas aren't useful (don't reduce)

- [ ] Level 47: why does table show up

- [ ] Level 56: why does method drawer show up (not really useable though)

- [ ] Level 58: spacing of parenthesis (e.g. try x + 2)

- [ ] Level 61: why does true+false even work

- [ ] There is a layout bug for typing arrays (TypeInArrayExpr) inside ObjExtensionExprs. The arguments do not layout properly. After an hour of searching I found it's a clone bug on line 530+537, but if you add .clone(), it breaks typing inside argument expressions... (ノ°Д°）ノ︵ ┻━┻ More specifically it still lets you type, but the argument you're typing in is no longer attached (parent == null). I suspect it's an issue with cloning TypeInTextExprs... 