### PR TITLE
Lambda fixes/toJavaScript for ObjectExtensionExpr

### DIFF
--- a/src/expr/lambda.js
+++ b/src/expr/lambda.js
@@ -325,7 +325,7 @@ class LambdaHoleExpr extends MissingExpression {
                             c.pos = n.absolutePos;
                             c.scale = n.absoluteScale;
                             // Lock child nodes that are not placeholders
-                            c.lockSubexpressions((e) => !e.isPlaceholder());
+                            c.lockSubexpressions((e) => !(e.isPlaceholder() || e instanceof LambdaHoleExpr));
                             let pos = addPos(c.pos, {x:0, y:-40});
                             final_nodes.push( c );
                         });
@@ -755,7 +755,8 @@ class LambdaExpr extends Expression {
                     reduced_expr.forEach((e) => {
                         if (this.locked) e.lock();
                         else             e.unlock();
-                        e.lockSubexpressions();
+                        e.lockSubexpressions((node) => !(node.isPlaceholder() ||
+                                                         node instanceof LambdaHoleExpr));
                     });
                     parent.swap(this, reduced_expr); // swap 'this' (on the board) with an array of its reduced expressions
                     parent.saveState();
@@ -767,7 +768,9 @@ class LambdaExpr extends Expression {
             if (this.locked) reduced_expr.lock(); // the new expression should inherit whatever this expression was capable of as input
             else             reduced_expr.unlock();
             //console.warn(this, reduced_expr);
-            reduced_expr.lockSubexpressions();
+            reduced_expr.lockSubexpressions((node) => !(node.isPlaceholder() ||
+                                                        node instanceof LambdaHoleExpr));
+
             if (parent) parent.swap(this, reduced_expr);
 
             if (reduced_expr.parent) {

--- a/src/expr/lambda.js
+++ b/src/expr/lambda.js
@@ -324,7 +324,13 @@ class LambdaHoleExpr extends MissingExpression {
                             c.anchor = n.anchor;
                             c.pos = n.absolutePos;
                             c.scale = n.absoluteScale;
-                            let pos = addPos(c.pos, {x:0, y:-40})
+                            // Lock child nodes that are not placeholders
+                            mag.Stage.getAllNodes([c]).forEach((node) => {
+                                if (node instanceof Expression && !node.isPlaceholder()) {
+                                    node.lock();
+                                }
+                            });
+                            let pos = addPos(c.pos, {x:0, y:-40});
                             final_nodes.push( c );
                         });
 

--- a/src/expr/lambda.js
+++ b/src/expr/lambda.js
@@ -325,11 +325,7 @@ class LambdaHoleExpr extends MissingExpression {
                             c.pos = n.absolutePos;
                             c.scale = n.absoluteScale;
                             // Lock child nodes that are not placeholders
-                            mag.Stage.getAllNodes([c]).forEach((node) => {
-                                if (node instanceof Expression && !node.isPlaceholder()) {
-                                    node.lock();
-                                }
-                            });
+                            c.lockSubexpressions((e) => !e.isPlaceholder());
                             let pos = addPos(c.pos, {x:0, y:-40});
                             final_nodes.push( c );
                         });

--- a/src/expr/obj.js
+++ b/src/expr/obj.js
@@ -382,6 +382,9 @@ class ObjectExtensionExpr extends ExpressionPlus {
         this.objMethods = objMethods;
         // TBI
 
+        // Keep track of what the current state is (whether we have a
+        // method call and what the call is)
+        this._currentMethod = null;
     }
     onmousedrag(pos) {
         super.onmousedrag(pos);
@@ -548,6 +551,11 @@ class ObjectExtensionExpr extends ExpressionPlus {
 
         this.removeChild(this.drawer);
         this.drawer = null;
+
+        this._currentMethod = {
+            name: methodText,
+            args: argExprs,
+        };
     }
 
     isValue() { return !this.subReduceMethod; }
@@ -564,7 +572,15 @@ class ObjectExtensionExpr extends ExpressionPlus {
     }
 
     toJavaScript() {
-        return '__OBJECT_EXT_EXPR()'; // TO BE IMPLEMENTED!
+        let methodText = "";
+        if (this._currentMethod !== null) {
+            const parts = [];
+            for (let arg of this._currentMethod.args) {
+                parts.push(arg.toJavaScript());
+            }
+            methodText = `.${this._currentMethod.name}(${parts.join(", ")})`;
+        }
+        return `${this.holes[0].toJavaScript()}${methodText}`;
     }
 }
 

--- a/src/expr/recall.js
+++ b/src/expr/recall.js
@@ -676,6 +676,11 @@ class TypeInTextExpr extends TextExpr {
                 if (!(parent instanceof mag.Stage))
                     expr.lock();
                 expr.update();
+                // Make sure everything updates & everything gets laid out properly
+                while (parent) {
+                    parent.update();
+                    parent = parent.parent;
+                }
             };
             this.afterCommit = afterCommit;
         }


### PR DESCRIPTION
Allow equality comparisons with a lambda, which prevents a confusing "stuck" case in level 32 if the user applies the lambdas in the wrong order. (It'll now reduce to False, and then the game will ask them to reset, instead of blinking the lambda parameter that they cannot use.)

Expressions passed through a duplicating lambda have their non-placeholder, non-lambda-hole subexpressions locked now. This also fixes nested lambdas (which before couldn't be applied after the outer lambda was applied).

This also implements `toJavaScript` for ObjectExtensionExpr now.