### PR TITLE
Fix Map, lambda application with textboxes; save state where needed

### DIFF
--- a/resources/levels/map.json
+++ b/resources/levels/map.json
@@ -7,7 +7,11 @@
             "description": "Intro to map, leveraging math knowledge.",
             "board": "[1, 2, 3].map(x => x + 1)",
             "goal": "[2, 3, 4]",
-            "toolbox": ""
+            "toolbox": "",
+            "fade": {
+                "map": 1
+            },
+            "showFade": false
         },
         {
             "description": "Intro to map: Typing.",

--- a/src/expr/expression.js
+++ b/src/expr/expression.js
@@ -324,6 +324,17 @@ class Expression extends mag.RoundedRect {
     // Wrapper for performReduction intended for interactive use
     performUserReduction() {
         if (!this._reducing) {
+            // Text boxes simulate a user click, causing us to reduce
+            // twice. We temporarily set the reducing flag to prevent
+            // re-entrant reduction, which causes problems for
+            // expressions that have side effects upon reduction
+            // (e.g. Sequences).
+            this._reducing = true;
+            mag.Stage.getNodesWithClass(TypeInTextExpr, [], true, [this]).forEach((n) => {
+                if (n.canReduce()) {
+                    n.reduce();
+                }
+            });
             if (!this.canReduce()) {
                 mag.Stage.getAllNodes([this]).forEach((n) => {
                     if (n instanceof Expression && n.isPlaceholder()) {
@@ -332,6 +343,7 @@ class Expression extends mag.RoundedRect {
                         n.animatePlaceholderStatus();
                     }
                 });
+                this._reducing = false;
                 return Promise.reject("Expression: expression cannot reduce");
             }
             console.log('Can reduce?: ', this.canReduce());

--- a/src/expr/lambda.js
+++ b/src/expr/lambda.js
@@ -456,6 +456,10 @@ class LambdaHoleExpr extends MissingExpression {
         }
     }
 
+    isPlaceholder() {
+        return false;
+    }
+
     toString() { return 'λ' + this.name; }
 }
 

--- a/src/expr/lambda.js
+++ b/src/expr/lambda.js
@@ -289,14 +289,23 @@ class LambdaHoleExpr extends MissingExpression {
         const hasTextbox = (n) => {
             if (n && n.hasPlaceholderChildren()) {
                 const placeholders = n.getPlaceholderChildren();
-                if (placeholders.every((e) => e instanceof MissingExpression))
-                    return false;
-                else {
-                    // Blink the relevant placeholders.
-                    n.animatePlaceholderChildren();
-                    this.ondropexit(node, pos);
-                    console.log(n);
-                    return true;
+                for (const placeholder of placeholders) {
+                    // If the placeholder is filled and valid, lock it
+                    if (placeholder instanceof TypeInTextExpr) {
+                        if (placeholder.canReduce()) {
+
+                        }
+                        else {
+                            // Blink the relevant placeholders.
+                            n.animatePlaceholderChildren();
+                            this.ondropexit(node, pos);
+                            console.log(n);
+                            return true;
+                        }
+                    }
+                    else {
+                        return false;
+                    }
                 }
             }
             return false;

--- a/src/expr/meta.js
+++ b/src/expr/meta.js
@@ -44,6 +44,7 @@ class InfiniteExpression extends GraphicValueExpr {
         // and let the user drag the clone.
         let c = this.graphicNode.clone();
         this.stage.add(c);
+        this.stage.saveState();
         Resource.play('place');
         c.onmouseenter(pos);
         c.onmousedrag(pos);

--- a/src/expr/recall.js
+++ b/src/expr/recall.js
@@ -699,10 +699,12 @@ class TypeInTextExpr extends TextExpr {
                 Logger.log('after-commit-text', {'text': txt, 'rootParent':rootParent ? rootParent.toJavaScript() : 'UNKNOWN' });
                 if (stage) stage.saveState();
 
-                // Also reduce the root parent if possible
-                // (removes need for redundant clicking)
+                // Also reduce the root parent if possible (removes
+                // need for redundant clicking). Don't reduce things
+                // that are already in the process of reducing,
+                // though.
                 if (rootParent && !rootParent.hasPlaceholderChildren() &&
-                    !(rootParent instanceof LambdaExpr))
+                    !(rootParent instanceof LambdaExpr) && !rootParent._reducting)
                     rootParent.performUserReduction();
             } else {
                 Animate.blink(this, 1000, [1, 0, 0], 2); // blink red

--- a/src/expr/var.js
+++ b/src/expr/var.js
@@ -173,7 +173,9 @@ class LabeledVarExpr extends VarExpr {
         if (value != this) {
             value = value.clone();
             let parent = this.parent ? this.parent : this.stage;
+            const stage = this.stage;
             parent.swap(this, value);
+            stage.saveState();
             return Promise.resolve(value);
         }
         else {
@@ -280,7 +282,9 @@ class ChestVarExpr extends VarExpr {
         if (value != this) {
             if (!animated) {
                 let parent = this.parent ? this.parent : this.stage;
+                const stage = this.stage;
                 parent.swap(this, value);
+                this.stage.saveState();
                 return Promise.resolve(value);
             }
             this._animating = true;
@@ -345,6 +349,7 @@ class ChestVarExpr extends VarExpr {
                     }
                     stage.draw();
                     stage.update();
+                    stage.saveState();
                     resolve(value);
                 }, 200);
             });
@@ -394,12 +399,16 @@ class JumpingChestVarExpr extends ChestVarExpr {
         };
         let lerp = arcLerp(value.absolutePos.y, this.absolutePos.y);
         Resource.play('fall-to');
+
+        const stage = this.stage;
+
         return new Promise((resolve, _reject) => {
             Animate.tween(value, target, 600, (x) => x, true, lerp).after(() => {
                 this.stage.remove(value);
                 this.stage.draw();
                 window.setTimeout(() => {
                     super.performReduction(true).then((value) => {
+                        stage.saveState();
                         resolve(value);
                     });
                 }, 100);
@@ -544,6 +553,9 @@ class AssignExpr extends Expression {
         });
         this.stage.update();
         this.stage.draw();
+        const stage = this.stage;
+        stage.swap(this, null);
+        stage.saveState();
     }
 
     animateReduction() {

--- a/src/frame/parseES6.js
+++ b/src/frame/parseES6.js
@@ -187,7 +187,7 @@ class ES6Parser {
                 } else if (node.callee.type === 'Identifier' && node.callee.name === '_op') { // Special case: Operators like +, =, !=, ==, etc...
                     return new OpLiteral(node.arguments[0].value);
                 } else if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'map') {
-                    return new (ExprManager.getClass('arrayobj'))(this.parseNode(node.callee.object), 'map', this.parseNode(node.arguments[0]));
+                    return new (ExprManager.getClass('map'))(this.parseNode(node.arguments[0]), this.parseNode(node.callee.object));
                 } else if (node.callee.type === 'Identifier') {
 
                     if (node.callee.name.substring(0, 2) === '_t') {

--- a/src/func/func.js
+++ b/src/func/func.js
@@ -16,7 +16,7 @@ class FuncExpr extends Expression {
     }
 
     onmouseclick(pos) {
-        this.performReduction();
+        this.performUserReduction();
     }
 
     draw(ctx, offset) {

--- a/src/func/map.js
+++ b/src/func/map.js
@@ -149,10 +149,9 @@ class MapFunc extends FuncExpr {
 
                 // debug
                 if (!this.animatedReduction) {
-                    superReduce().then(() => {
-                        this.bag.spill(false); // don't log this spill
-                        stage.remove(this.bag);
-                    });
+                    // Don't spill the bag onto the board - leave the
+                    // array as is
+                    superReduce();
                     return;
                 }
                 else this.bag.lock();

--- a/src/func/map.js
+++ b/src/func/map.js
@@ -88,6 +88,26 @@ class MapFunc extends FuncExpr {
         return `${this.bag.toJavaScript()}.map(${this.func.toJavaScript()})`;
     }
 
+    canReduce() {
+        if (!this.bag || !this.func) {
+            return false;
+        }
+
+        if (this.func.hasPlaceholderChildren()) {
+            const placeholders = this.func.getPlaceholderChildren();
+            for (const placeholder of placeholders) {
+                // If the placeholder is filled and valid, lock it
+                if (placeholder instanceof TypeInTextExpr) {
+                    if (placeholder.canReduce()) {
+                        continue;
+                    }
+                }
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     reduce() {
         this.update();


### PR DESCRIPTION
- Applying a lambda with a filled, valid textbox now automatically commits the textbox.
- Lambda holes no longer count as placeholders (so they won't blink unnecessarily)
- Use the hardcoded MapFunc, with changes to make it behave more like the ArrayObjectExpr version
  - Autocommits text boxes
  - Blinks incomplete text boxes
  - Does not spill the bag (unlike the concrete version)
- Save state after assignment, reducing variable
- Fix issue with reducing a sequence by clicking when it has a text box (see commit message/comments in committed code)