### PR TITLE
Fix case where dragging from toolbox would lead to unusable expr

### DIFF
--- a/src/expr/expression.js
+++ b/src/expr/expression.js
@@ -636,6 +636,7 @@ class Expression extends mag.RoundedRect {
             Logger.log('detach-commit', this.toString());
         }
         let toplevel = this.rootParent;
+        if (!toplevel) toplevel = this;
         if (this.dragging || toplevel.dragging) {
              if (toplevel.toolbox && !toplevel.toolbox.hits(pos)) {
                 toplevel.toolbox = null;

--- a/src/expr/expression.js
+++ b/src/expr/expression.js
@@ -635,18 +635,20 @@ class Expression extends mag.RoundedRect {
 
             Logger.log('detach-commit', this.toString());
         }
-        if (this.dragging) {
-            if (this.toolbox && !this.toolbox.hits(pos)) {
-                this.toolbox = null;
+        let toplevel = this.rootParent;
+        if (this.dragging || toplevel.dragging) {
+             if (toplevel.toolbox && !toplevel.toolbox.hits(pos)) {
+                toplevel.toolbox = null;
 
-                Logger.log('toolbox-remove', this.toString());
+                Logger.log('toolbox-remove', toplevel.toString());
 
-                ShapeExpandEffect.run(this, 500, (e) => Math.pow(e, 0.5), 'white', 1.5);
+                ShapeExpandEffect.run(toplevel, 500, (e) => Math.pow(e, 0.5), 'white', 1.5);
 
-                if (this.stage)
-                    this.stage.saveState({name:'toolbox-remove', item:this.toJavaScript()});
+                if (toplevel.stage)
+                    toplevel.stage.saveState({name:'toolbox-remove', item:toplevel.toJavaScript()});
             }
-
+        }
+        if (this.dragging) {
             // Snap expressions together?
             if (this._prev_notch_objs && this._prev_notch_objs.length > 0) {
                 let closest = Array.minimum(this._prev_notch_objs, 'dist');


### PR DESCRIPTION
This is not the most important PR, but it fixes a case that has occasionally bugged me for the past year: sometimes, when you drag an expression from the toolbox, you can't attach any expressions to it until you drag it around.

If an expression is dragged from the toolbox by holding a
MissingExpression child, the Expression.toolbox property won't get
properly cleared. This changes the logic to try and clear the
toolbox property on the root of the element being dragged.