### PR TITLE
More bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules
 log_analyzer/nodejs-log-listener/userlogs/*
 resources/graphics/assets.png
 resources/graphics/starboy/menu-assets.png
+*.kra
+#*#
+*.xcf
+*.el
+*~

--- a/resources/graphics/assets.json
+++ b/resources/graphics/assets.json
@@ -77,7 +77,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":286,"h":166},
 			"sourceSize": {"w":286,"h":166}
 		},
-		"funnel-selected.png":
+		"funnel.png":
 		{
 			"frame": {"x":1926,"y":1289,"w":198,"h":281},
 			"rotated": false,
@@ -85,7 +85,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":198,"h":281},
 			"sourceSize": {"w":198,"h":281}
 		},
-		"funnel.png":
+		"funnel-selected.png":
 		{
 			"frame": {"x":1926,"y":1574,"w":198,"h":281},
 			"rotated": false,
@@ -197,7 +197,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":135,"h":177},
 			"sourceSize": {"w":135,"h":177}
 		},
-		"lambda-pipe-x-opening1.png":
+		"lambda-pipe-x-opening2.png":
 		{
 			"frame": {"x":2517,"y":403,"w":160,"h":166},
 			"rotated": false,
@@ -205,7 +205,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":160,"h":166},
 			"sourceSize": {"w":160,"h":166}
 		},
-		"lambda-pipe-x-opening0.png":
+		"lambda-pipe-x-opening1.png":
 		{
 			"frame": {"x":2517,"y":573,"w":160,"h":166},
 			"rotated": false,
@@ -213,7 +213,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":160,"h":166},
 			"sourceSize": {"w":160,"h":166}
 		},
-		"lambda-pipe-x-open.png":
+		"lambda-pipe-x-opening0.png":
 		{
 			"frame": {"x":2517,"y":743,"w":160,"h":166},
 			"rotated": false,
@@ -237,7 +237,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":160,"h":166},
 			"sourceSize": {"w":160,"h":166}
 		},
-		"lambda-pipe-x-opening3.png":
+		"lambda-pipe-x-open.png":
 		{
 			"frame": {"x":2517,"y":1253,"w":160,"h":166},
 			"rotated": false,
@@ -245,7 +245,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":160,"h":166},
 			"sourceSize": {"w":160,"h":166}
 		},
-		"lambda-pipe-x-opening2.png":
+		"lambda-pipe-x-opening3.png":
 		{
 			"frame": {"x":2517,"y":1423,"w":160,"h":166},
 			"rotated": false,
@@ -349,7 +349,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":112,"h":128},
 			"sourceSize": {"w":112,"h":128}
 		},
-		"mirror-icon.png":
+		"mirror-icon-fade-false-righthalf.png":
 		{
 			"frame": {"x":2353,"y":1171,"w":115,"h":118},
 			"rotated": false,
@@ -357,7 +357,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":115,"h":118},
 			"sourceSize": {"w":115,"h":118}
 		},
-		"mirror-icon-fade-true.png":
+		"mirror-icon.png":
 		{
 			"frame": {"x":2353,"y":1293,"w":115,"h":118},
 			"rotated": false,
@@ -365,7 +365,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":115,"h":118},
 			"sourceSize": {"w":115,"h":118}
 		},
-		"mirror-icon-fade-false-righthalf.png":
+		"mirror-icon-fade-true.png":
 		{
 			"frame": {"x":2353,"y":1415,"w":115,"h":118},
 			"rotated": false,
@@ -373,7 +373,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":115,"h":118},
 			"sourceSize": {"w":115,"h":118}
 		},
-		"mirror-icon-fade-false-lefthalf.png":
+		"mirror-icon-fade-false.png":
 		{
 			"frame": {"x":2353,"y":1537,"w":115,"h":118},
 			"rotated": false,
@@ -405,7 +405,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":112,"h":73},
 			"sourceSize": {"w":112,"h":73}
 		},
-		"btn-hamburger-default.png":
+		"btn-back-down.png":
 		{
 			"frame": {"x":2353,"y":1980,"w":104,"h":104},
 			"rotated": false,
@@ -429,7 +429,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-reset-down.png":
+		"btn-mute-default.png":
 		{
 			"frame": {"x":2191,"y":493,"w":104,"h":104},
 			"rotated": false,
@@ -437,7 +437,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-back-down.png":
+		"btn-reset-force.png":
 		{
 			"frame": {"x":2191,"y":601,"w":104,"h":104},
 			"rotated": false,
@@ -445,7 +445,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-reset-force.png":
+		"btn-reset-hover.png":
 		{
 			"frame": {"x":2191,"y":709,"w":104,"h":104},
 			"rotated": false,
@@ -453,7 +453,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-reset-hover.png":
+		"btn-back-default.png":
 		{
 			"frame": {"x":2191,"y":817,"w":104,"h":104},
 			"rotated": false,
@@ -461,7 +461,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-menu-down.png":
+		"btn-hamburger-default.png":
 		{
 			"frame": {"x":2191,"y":925,"w":104,"h":104},
 			"rotated": false,
@@ -469,7 +469,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-back-default.png":
+		"btn-next-down.png":
 		{
 			"frame": {"x":2191,"y":1033,"w":104,"h":104},
 			"rotated": false,
@@ -477,7 +477,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-menu-hover.png":
+		"btn-hamburger-down.png":
 		{
 			"frame": {"x":2191,"y":1141,"w":104,"h":104},
 			"rotated": false,
@@ -485,7 +485,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-mute-default.png":
+		"btn-next-default.png":
 		{
 			"frame": {"x":2191,"y":1249,"w":104,"h":104},
 			"rotated": false,
@@ -493,7 +493,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-reset-default.png":
+		"btn-hamburger-hover.png":
 		{
 			"frame": {"x":2191,"y":1357,"w":104,"h":104},
 			"rotated": false,
@@ -501,7 +501,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-next-down.png":
+		"btn-reset-default.png":
 		{
 			"frame": {"x":2191,"y":1465,"w":104,"h":104},
 			"rotated": false,
@@ -509,7 +509,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-next-default.png":
+		"btn-reset-down.png":
 		{
 			"frame": {"x":2191,"y":1573,"w":104,"h":104},
 			"rotated": false,
@@ -517,7 +517,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-hamburger-down.png":
+		"btn-menu-down.png":
 		{
 			"frame": {"x":2191,"y":1681,"w":104,"h":104},
 			"rotated": false,
@@ -525,7 +525,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-hamburger-hover.png":
+		"btn-menu-hover.png":
 		{
 			"frame": {"x":2191,"y":1789,"w":104,"h":104},
 			"rotated": false,
@@ -533,7 +533,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-mute-down.png":
+		"btn-menu-default.png":
 		{
 			"frame": {"x":1015,"y":1541,"w":104,"h":104},
 			"rotated": false,
@@ -541,7 +541,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-mute-hover.png":
+		"btn-mute-down.png":
 		{
 			"frame": {"x":1123,"y":1541,"w":104,"h":104},
 			"rotated": false,
@@ -549,7 +549,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"unmute-button.png":
+		"btn-mute-hover.png":
 		{
 			"frame": {"x":1231,"y":1541,"w":104,"h":104},
 			"rotated": false,
@@ -557,7 +557,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"unmute-button-hover.png":
+		"unmute-button-down.png":
 		{
 			"frame": {"x":1339,"y":1541,"w":104,"h":104},
 			"rotated": false,
@@ -565,7 +565,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"unmute-button-down.png":
+		"unmute-button-hover.png":
 		{
 			"frame": {"x":1447,"y":1541,"w":104,"h":104},
 			"rotated": false,
@@ -573,7 +573,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
 			"sourceSize": {"w":104,"h":104}
 		},
-		"btn-menu-default.png":
+		"unmute-button.png":
 		{
 			"frame": {"x":1555,"y":1541,"w":104,"h":104},
 			"rotated": false,
@@ -613,7 +613,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":72,"h":96},
 			"sourceSize": {"w":72,"h":96}
 		},
-		"lambda-pipe-opening0.png":
+		"lambda-pipe-xside-closed.png":
 		{
 			"frame": {"x":1832,"y":1541,"w":72,"h":96},
 			"rotated": false,
@@ -621,7 +621,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":72,"h":96},
 			"sourceSize": {"w":72,"h":96}
 		},
-		"lambda-pipe-xside-closed.png":
+		"lambda-pipe-opening0.png":
 		{
 			"frame": {"x":1017,"y":1691,"w":72,"h":96},
 			"rotated": false,
@@ -629,7 +629,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":72,"h":96},
 			"sourceSize": {"w":72,"h":96}
 		},
-		"lambda-pipe-white.png":
+		"lambda-pipe.png":
 		{
 			"frame": {"x":1093,"y":1691,"w":72,"h":96},
 			"rotated": false,
@@ -637,7 +637,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":72,"h":96},
 			"sourceSize": {"w":72,"h":96}
 		},
-		"lambda-pipe.png":
+		"lambda-pipe-open.png":
 		{
 			"frame": {"x":1169,"y":1691,"w":72,"h":96},
 			"rotated": false,
@@ -645,7 +645,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":72,"h":96},
 			"sourceSize": {"w":72,"h":96}
 		},
-		"lambda-pipe-open.png":
+		"lambda-pipe-white.png":
 		{
 			"frame": {"x":1245,"y":1691,"w":72,"h":96},
 			"rotated": false,
@@ -669,7 +669,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":90,"h":90},
 			"sourceSize": {"w":90,"h":90}
 		},
-		"poof0.png":
+		"poof3.png":
 		{
 			"frame": {"x":1491,"y":1691,"w":90,"h":90},
 			"rotated": false,
@@ -685,7 +685,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":90,"h":90},
 			"sourceSize": {"w":90,"h":90}
 		},
-		"poof3.png":
+		"poof0.png":
 		{
 			"frame": {"x":1679,"y":1691,"w":90,"h":90},
 			"rotated": false,
@@ -701,7 +701,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":90,"h":90},
 			"sourceSize": {"w":90,"h":90}
 		},
-		"missing-bracket-selected.png":
+		"missing-bracket.png":
 		{
 			"frame": {"x":1398,"y":1918,"w":84,"h":88},
 			"rotated": false,
@@ -709,7 +709,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":84,"h":88},
 			"sourceSize": {"w":84,"h":88}
 		},
-		"missing-bracket.png":
+		"missing-bracket-selected.png":
 		{
 			"frame": {"x":1486,"y":1918,"w":84,"h":88},
 			"rotated": false,
@@ -733,7 +733,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":45,"h":65},
 			"sourceSize": {"w":45,"h":65}
 		},
-		"null1-highlighted.png":
+		"null-circle.png":
 		{
 			"frame": {"x":2116,"y":702,"w":64,"h":64},
 			"rotated": false,
@@ -741,7 +741,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
 			"sourceSize": {"w":64,"h":64}
 		},
-		"null-circle.png":
+		"null1-highlighted.png":
 		{
 			"frame": {"x":2116,"y":770,"w":64,"h":64},
 			"rotated": false,
@@ -749,7 +749,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
 			"sourceSize": {"w":64,"h":64}
 		},
-		"empty-typebox-string.png":
+		"empty-typebox.png":
 		{
 			"frame": {"x":2454,"y":2088,"w":46,"h":44},
 			"rotated": false,
@@ -757,7 +757,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":46,"h":44},
 			"sourceSize": {"w":46,"h":44}
 		},
-		"empty-typebox.png":
+		"empty-typebox-string.png":
 		{
 			"frame": {"x":2299,"y":277,"w":46,"h":44},
 			"rotated": false,
@@ -773,7 +773,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":25,"h":41},
 			"sourceSize": {"w":25,"h":41}
 		},
-		"mirror-icon-fade-false.png":
+		"mirror-icon-fade-false-lefthalf.png":
 		{
 			"frame": {"x":2353,"y":1781,"w":115,"h":118},
 			"rotated": false,

--- a/resources/graphics/starboy/menu-assets.json
+++ b/resources/graphics/starboy/menu-assets.json
@@ -53,7 +53,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":853,"h":853},
 			"sourceSize": {"w":853,"h":853}
 		},
-		"ship-large-starboy.png":
+		"ship-large.png":
 		{
 			"frame": {"x":2,"y":1815,"w":818,"h":700},
 			"rotated": false,
@@ -61,7 +61,7 @@
 			"spriteSourceSize": {"x":0,"y":0,"w":818,"h":700},
 			"sourceSize": {"w":818,"h":700}
 		},
-		"ship-large.png":
+		"ship-large-starboy.png":
 		{
 			"frame": {"x":824,"y":1815,"w":818,"h":700},
 			"rotated": false,

--- a/src/core/stage.js
+++ b/src/core/stage.js
@@ -309,6 +309,7 @@ var mag = (function(_) {
                 if (!(n instanceof Expression) || n.toolbox) return;
 
                 const left = n.pos.x - n.anchor.x * n.absoluteSize.w;
+                const top = n.pos.y - n.anchor.y * n.absoluteSize.h;
                 const right = left + n.absoluteSize.w;
 
                 // Resize nodes that are too large
@@ -327,6 +328,10 @@ var mag = (function(_) {
                     const overhang = right - this.boundingSize.w;
                     const p = n.pos;
                     n.pos = { x: p.x - overhang, y: p.y };
+                }
+
+                if (top < 0) {
+                    n.pos = { x: n.pos.x, y: n.pos.y - top };
                 }
             });
         }

--- a/src/expr/collection.js
+++ b/src/expr/collection.js
@@ -97,7 +97,7 @@ class BagExpr extends CollectionExpr {
         let items = this.items.map((i) => i.clone());
         bag.items = [];
         let new_items = [];
-        items.forEach((item) => {
+        for (let item of items) {
             let c = item.clone();
             let pos = item.pos;
             let func = lambdaExpr.clone();
@@ -111,6 +111,14 @@ class BagExpr extends CollectionExpr {
             let new_funcs = func.applyExpr(c);
             if (!Array.isArray(new_funcs)) new_funcs = [ new_funcs ];
 
+            // Check for null values - this means the lambda could not reduce
+            for (let new_func of new_funcs) {
+                if (new_func === null || typeof new_func === "undefined") {
+                    WatEffect.run(lambdaExpr);
+                    return undefined;
+                }
+            }
+
             for (let new_func of new_funcs) {
                 new_func.pos = pos;
                 new_func.unlockSubexpressions();
@@ -118,8 +126,7 @@ class BagExpr extends CollectionExpr {
                 bag.addItem(new_func.reduceCompletely());
                 this.stage.remove(new_func);
             }
-        });
-        //bag.items = new_items;
+        }
         return bag;
     }
 

--- a/src/expr/lambda.js
+++ b/src/expr/lambda.js
@@ -388,9 +388,27 @@ class LambdaHoleExpr extends MissingExpression {
 
                         const layout_vertical = (overlap_layout && total_width > 420) || off_screen;
                         if (layout_vertical) {
+                            // If goes off screen vertically, use the
+                            // space below the lambda instead
+
+                            let yPos = (c, i) => {
+                                return c.pos.y - 60 - ((len - i - 1) / len * total_height) + i * 10;
+                            };
+
+                            for (let i = 0; i < final_nodes.length; i++) {
+                                const c = final_nodes[i];
+                                let y = yPos(c, i);
+                                if (y - c.scale.y * c.size.h < 0) {
+                                    yPos = (c, i) => {
+                                        return c.pos.y + 60 - ((len - i - 1) / len * total_height) + i * 10;
+                                    };
+                                    break;
+                                }
+                            }
+
                             final_nodes.forEach((c, i) => {
                                 let final_pos = { x:mid_xpos,
-                                                  y:c.pos.y - 60 - ((len - i - 1) / len * total_height) + i * 10 };
+                                                  y:yPos(c, i) };
                                 stage.add(c);
                                 Animate.tween(c, {scale:{x:1, y:1}, pos:final_pos}, 300, (e) => Math.pow(e, 0.5)).after(() => {
                                     c.onmouseleave();

--- a/src/expr/lambda.js
+++ b/src/expr/lambda.js
@@ -411,6 +411,14 @@ class LambdaHoleExpr extends MissingExpression {
                             });
                         }
                     }
+                    else {
+                        // There are variables without a value
+                        mag.Stage.getAllNodes([lambdaExpr]).forEach((n) => {
+                            if (n instanceof LambdaVarExpr) {
+                                Animate.blink(n, 500, [1, 0, 0], 1);
+                            }
+                        });
+                    }
                     this.close_opened_subexprs();
                 }
 

--- a/src/expr/var.js
+++ b/src/expr/var.js
@@ -181,21 +181,23 @@ class LabeledVarExpr extends VarExpr {
             return Promise.resolve(value);
         }
         else {
-            let wat = new TextExpr("?");
-            this.stage.add(wat);
-            wat.pos = this.label.absolutePos;
-            Animate.tween(wat, {
-                pos: {
-                    x: wat.pos.x,
-                    y: wat.pos.y - 50,
-                },
-            }, 250);
-            window.setTimeout(() => {
-                Animate.poof(wat);
-                this.stage.remove(wat);
-                this.stage.draw();
-                this.stage.update();
-            }, 500);
+            if (this.stage) {
+                let wat = new TextExpr("?");
+                this.stage.add(wat);
+                wat.pos = this.label.absolutePos;
+                Animate.tween(wat, {
+                    pos: {
+                        x: wat.pos.x,
+                        y: wat.pos.y - 50,
+                    },
+                }, 250);
+                window.setTimeout(() => {
+                    Animate.poof(wat);
+                    this.stage.remove(wat);
+                    this.stage.draw();
+                    this.stage.update();
+                }, 500);
+            }
             return Promise.reject("Cannot reduce undefined variable");
         }
     }

--- a/src/frame/reductstage.js
+++ b/src/frame/reductstage.js
@@ -213,7 +213,8 @@ class ReductStage extends mag.Stage {
             // If the goal is an array, and no MapExprs remain,
             // then this level can't be completed no matter what is left.
             if (this.goalNodes.every(e => e instanceof BracketArrayExpr) &&
-                !(remaining_exprs.some(e => e instanceof MapFunc)))
+                !(remaining_exprs.some(e => e instanceof MapFunc)) &&
+                this.getNodesWithClass(TypeInTextExpr).length === 0)
                 return false;
 
             return true;

--- a/src/func/map.js
+++ b/src/func/map.js
@@ -151,7 +151,14 @@ class MapFunc extends FuncExpr {
                 if (!this.animatedReduction) {
                     // Don't spill the bag onto the board - leave the
                     // array as is
-                    return superReduce();
+                    return new Promise((resolve, _reject) => {
+                        var shatter = new ShatterExpressionEffect(this);
+                        shatter.run(stage, (() => {
+                            this.ignoreEvents = false;
+                            resolve(superReduce());
+                        }).bind(this));
+                        this.ignoreEvents = true;
+                    });
                 }
                 else this.bag.lock();
 
@@ -271,6 +278,8 @@ class MapFunc extends FuncExpr {
             }
 
         }
+
+        return Promise.reject("Cannot reduce Map");
     }
 
     // Sizes to match its children.

--- a/src/func/map.js
+++ b/src/func/map.js
@@ -278,6 +278,24 @@ class MapFunc extends FuncExpr {
             }
 
         }
+        else if (!(this.func instanceof LambdaExpr)) {
+            let wat = new TextExpr("?");
+            this.stage.add(wat);
+            wat.pos = this.func.absolutePos;
+            Animate.tween(wat, {
+                pos: {
+                    x: wat.pos.x,
+                    y: wat.pos.y - 50,
+                },
+            }, 250);
+            window.setTimeout(() => {
+                Animate.poof(wat);
+                this.stage.remove(wat);
+                this.stage.draw();
+                this.stage.update();
+            }, 500);
+            return Promise.reject("Cannot reduce map; attempting to apply non-function");
+        }
 
         return Promise.reject("Cannot reduce Map");
     }

--- a/src/func/map.js
+++ b/src/func/map.js
@@ -279,21 +279,7 @@ class MapFunc extends FuncExpr {
 
         }
         else if (!(this.func instanceof LambdaExpr)) {
-            let wat = new TextExpr("?");
-            this.stage.add(wat);
-            wat.pos = this.func.absolutePos;
-            Animate.tween(wat, {
-                pos: {
-                    x: wat.pos.x,
-                    y: wat.pos.y - 50,
-                },
-            }, 250);
-            window.setTimeout(() => {
-                Animate.poof(wat);
-                this.stage.remove(wat);
-                this.stage.draw();
-                this.stage.update();
-            }, 500);
+            WatEffect.run(this.func);
             return Promise.reject("Cannot reduce map; attempting to apply non-function");
         }
 

--- a/src/init.js
+++ b/src/init.js
@@ -8,7 +8,7 @@ var stage;
 var canvas;
 
 var __ACTIVE_LEVEL_VARIANT = 'block_variant';
-const __DEBUG_DISPLAY_STATEGRAPH = false;
+const __DEBUG_DISPLAY_STATEGRAPH = true;
 
 const __VIS_CANVAS_ID = 'stateGraphCanvas';
 const __STATEGRAPH_DISPLAY_EDGES = false;


### PR DESCRIPTION
- Adds shatter animation to Map
- Bring up question mark effect if Map is given a non-lambda/invalid lambda (this still needs tweaking, especially in the second case!)
- Replication result is placed below lambda if needed
- If expr goes beyond top of stage, bring it back inside
- Fixed mightBeCompleted to not give false negative on verbatim typing of map exprs

I'm not sure what is wrong with the x-positioning of Map results - should it be that their left edges line up instead of their centers? Also, I think the bug with hints not being cleared has been fixed already. 