### PR TITLE
Make CompareExpr nestable, especially with + op

### DIFF
--- a/src/expr/number.js
+++ b/src/expr/number.js
@@ -72,7 +72,7 @@ class OperatorExpr extends Expression {
         }).then((right) => {
             let stage = this.stage;
 
-            if (animated) {
+            if (animated && stage) {
                 return new Promise((resolve, _reject) => {
                     var shatter = new ShatterExpressionEffect(this);
                     shatter.run(stage, (() => {


### PR DESCRIPTION
On level 35, try building the entire expression before reducing - it won't work because the logic to swap the CompareExpr with the AddExpr is in performUserReduction. This moves the logic to performReduction and fixes a bug to make sure these expressions can nest.