### PR TITLE
Show ENTER hint when a typing challenge is issued.

### DIFF
--- a/src/expr/missing.js
+++ b/src/expr/missing.js
@@ -123,6 +123,8 @@ class MissingExpression extends Expression {
                     wrapper.anchor = anchor;
                     //wrapper.color = 'magenta';
 
+                    showHelpText("Press ENTER when finished typing.");
+
                     ShapeExpandEffect.run(wrapper, 500, (e) => Math.pow(e, 0.5), 'magenta', 1.5);
 
                     challenge.focus();


### PR DESCRIPTION
You may or may not want this; it simply shows a typing hint when an expression turns into a typing challenge.